### PR TITLE
Fix local variable referenced before assignment

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -221,6 +221,7 @@ class AlarmSkill(MycroftSkill):
                         self.__schedule_event(date, speak)
                 else:
                     self.speak_dialog('no.time.found')
+                    return
                 self.speak_dialog(
                     'alarm.scheduled', data=dict(time=speak))
                 self._store_alarm((str(date), speak))


### PR DESCRIPTION
If the thread doesn't return in that branch, the `speak` variable is never created (and it shouldn't say it scheduled an alarm if it didn't find a time)