### PR TITLE
Fix issue with unspecified time.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -304,7 +304,7 @@ class AlarmSkill(MycroftSkill):
 
         # Get the time
         when = extract_datetime(utt)
-        now = extract_datetime("now")
+        now = extract_datetime("dummy")  # Will return dt of unmatched string
         while not when or when[0] == now[0]:
             # No time given, ask for one
             r = self.get_response('query.for.when', num_retries=1)


### PR DESCRIPTION
A change in core started to parse "now" as the actual current time instead of not parsing it at all. The skill used it to find what the unparsed time would return.