### PR TITLE
Avoid creating alarms for the past time

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -408,8 +408,21 @@ class AlarmSkill(MycroftSkill):
                 alarm_time = when[0]
                 when = None  # reverify
 
+        alarm = None
         if not recur:
-            alarm = self.set_alarm(alarm_time)
+            alarm_time_ts = to_utc(alarm_time).timestamp()
+            now_ts = now_utc().timestamp()
+            if alarm_time_ts > now_ts:
+                alarm = self.set_alarm(alarm_time)
+            else:
+                if ('today' in utt) or ('tonight' in utt):
+                    self.speak_dialog('alarm.past')
+                    return
+                else:
+                    # Set the alarm on next weekday
+                    alarm_time_ts += 7 * 86400.0
+                    alarm_time = datetime.utcfromtimestamp(alarm_time_ts)
+                    alarm = self.set_alarm(alarm_time)
         else:
             alarm = self.set_alarm(alarm_time, repeat=recur)
 

--- a/dialog/en-us/alarm.past.dialog
+++ b/dialog/en-us/alarm.past.dialog
@@ -1,1 +1,2 @@
-I cannot set an alarm for the past time
+I cannot set an alarm in the past
+I can't set that time it has already passed

--- a/dialog/en-us/alarm.past.dialog
+++ b/dialog/en-us/alarm.past.dialog
@@ -1,0 +1,1 @@
+I cannot set an alarm for the past time


### PR DESCRIPTION
This PR handles 2 cases
1. Avoid creating alarms for the past time
  Some of the examples (assuming the current time is past the below time)
   - set an alarm for today/tonight at 8 a.m/p.m
   - set an alarm for today 9 in the morning/evening
2. Create an alarm for next week if
   - day specified is today and time specified is the past
 Example: If now = 4/11/2019 5:00 p.m, Thursday
   - set an alarm on thursday 8 a.m 
    should set the alarm for next week thursday 4/18/2019  8:00 a.m
