### PR TITLE
Remove deprecated values from Skills settingsmeta

### DIFF
--- a/settingsmeta.json
+++ b/settingsmeta.json
@@ -1,5 +1,4 @@
 {
-    "name": "Alarm",
     "skillMetadata": {
         "sections": [
             {


### PR DESCRIPTION
Removed skill name from settingsmeta.json (regarding issue #1092).