### PR TITLE
Report if an alarm was canceled due to stop

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -894,6 +894,9 @@ class AlarmSkill(MycroftSkill):
     def stop(self, message=None):
         if self.has_expired_alarm():
             self._stop_expired_alarm()
+            return True  # Stop signal handled no need to listen
+        else:
+            return False
 
     def _play_beep(self, message=None):
         """ Play alarm sound file """


### PR DESCRIPTION
The Mark-1 triggered listen when the top button is pressed to cancel an alarm. To make this work properly the skill not returns True if the stop method cancelled an alarm, otherwise False.