### PR TITLE
Fix cancel of single alarm if utt has no time

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -396,9 +396,10 @@ class AlarmSkill(MycroftSkill):
         # specify to set an alarm on midnight. If it's confirmed that
         # it's for a day only, then get another response from the user
         # to clarify what time on that day the recurring alarm is.
-        is_midnight = self._check_if_utt_has_midnight(utt,
-                                                      when,
-                                                      self.threshold)
+        if when is not None:
+            is_midnight = self._check_if_utt_has_midnight(utt,
+                                                          when,
+                                                          self.threshold)
 
         if (when is None or when.time() == today.time()) and not is_midnight:
             r = self.get_response('query.for.when')
@@ -652,9 +653,10 @@ class AlarmSkill(MycroftSkill):
         # specify to set an alarm on midnight. If it's confirmed that
         # it's for a day only, then get another response from the user
         # to clarify what time on that day the recurring alarm is.
-        is_midnight = self._check_if_utt_has_midnight(utt,
-                                                      when,
-                                                      self.threshold)
+        if when is not None:
+            is_midnight = self._check_if_utt_has_midnight(utt,
+                                                          when,
+                                                          self.threshold)
 
         if when == today and not is_midnight:
             when = None

--- a/test/intent/032.set.alarm.time.intent.json
+++ b/test/intent/032.set.alarm.time.intent.json
@@ -1,0 +1,7 @@
+{
+    "utterance": "set an alarm for 11am tomorrow",
+    "intent_type": "handle_set_alarm",
+    "responses": ["yes please"],
+    "expected_dialog": ["confirm.alarm",
+                        "alarm.scheduled"]
+}

--- a/test/intent/033.delete.single.alarm.time.none.intent.json
+++ b/test/intent/033.delete.single.alarm.time.none.intent.json
@@ -1,0 +1,7 @@
+{
+    "utterance": "cancel my alarm",
+    "intent_type": "handle_delete",
+    "responses": ["yes"],
+    "expected_dialog": ["ask.cancel.desc.alarm",
+                        "alarm.cancelled.desc"]
+}


### PR DESCRIPTION
"cancel alarm" without a time in the utterance would throw an error.
This would also prevent a single alarm being cancelled without stating it's time. 
This just prevents the Skill crashing, thereby allowing the alarm to be cancelled.

Tests added for this.