### PR TITLE
Fix test 32

### DIFF
--- a/test/intent/032.set.alarm.time.intent.json
+++ b/test/intent/032.set.alarm.time.intent.json
@@ -1,7 +1,5 @@
 {
     "utterance": "set an alarm for 11am tomorrow",
     "intent_type": "handle_set_alarm",
-    "responses": ["yes please"],
-    "expected_dialog": ["confirm.alarm",
-                        "alarm.scheduled"]
+    "expected_dialog": "alarm.scheduled.for.time"
 }


### PR DESCRIPTION
This test utterance gives an explicit time so no confirmation of the time is required.

As no confirmation is required a different dialog is used to report the time back to the user.