### PR TITLE
Fix datetime extraction on disambiguation

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -408,14 +408,16 @@ class AlarmSkill(MycroftSkill):
             when_temp = extract_datetime(r)
             if when_temp is not None:
                 when_temp = when_temp[0]
-                is_midnight = self._check_if_utt_has_midnight(r, when_temp,
-                                                              self.threshold)
-                when = datetime(tzinfo=when.tzinfo,
-                                year=when.year,
-                                month=when.month,
-                                day=when.day,
-                                hour=when_temp.hour,
-                                minute=when_temp.minute)
+                # TODO add check for midnight
+                # is_midnight = self._check_if_utt_has_midnight(r, when_temp,
+                #                                               self.threshold)
+                when = when_temp if when is None \
+                                 else datetime(tzinfo=when.tzinfo,
+                                               year=when.year,
+                                               month=when.month,
+                                               day=when.day,
+                                               hour=when_temp.hour,
+                                               minute=when_temp.minute)
             else:
                 when = None
 

--- a/test/intent/034.set.alarm.no.time.intent.json
+++ b/test/intent/034.set.alarm.no.time.intent.json
@@ -1,0 +1,6 @@
+{
+    "utterance": "set alarm",
+    "intent_type": "handle_set_alarm",
+    "responses": ["3 p.m."],
+    "expected_dialog": "alarm.scheduled.for.time"
+}

--- a/test/intent/035.set.alarm.no.time.intent.json
+++ b/test/intent/035.set.alarm.no.time.intent.json
@@ -1,0 +1,6 @@
+{
+    "utterance": "set alarm for next tuesday",
+    "intent_type": "handle_set_alarm",
+    "responses": ["4 p.m."],
+    "expected_dialog": "alarm.scheduled.for.time"
+}

--- a/test/intent/036.delete.alarm.all.empty.intent.json
+++ b/test/intent/036.delete.alarm.all.empty.intent.json
@@ -1,0 +1,5 @@
+{
+    "utterance": "cancel all my alarms",
+    "intent_type": "handle_delete",
+    "expected_dialog": "alarms.list.empty"
+}


### PR DESCRIPTION
Two general paths here:
1. "set timer" > "2pm"
  `when` is `None` so response datetime should be used
2. "set timer for Friday" > "2pm"
  response datetime would be extracted as today at 2pm so time of `when` is replaced with time from response.

Also `is_midnight` is assigned but never tested against, so have commented out until it's actually getting used.