### PR TITLE
require two keywords for adapt match

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -354,7 +354,7 @@ class AlarmSkill(MycroftSkill):
 
         return join_list(day_names, self.translate('and'))
 
-    @intent_handler(IntentBuilder("").optionally("Set").require("Alarm")
+    @intent_handler(IntentBuilder("").require("Set").require("Alarm")
                     .optionally("Recurring").optionally("Recurrence"))
     def handle_set_alarm(self, message):
         """Handler for "set an alarm for..."""


### PR DESCRIPTION
As the intent only requires a single keyword, this can match anything with the word "alarms" in it.

Requiring a verb [set, add, start, create] reduces the chance of false matching.

Currently seems to be occurring for some Skill PR's in mycroft-skills eg [MBTA Skill](https://jenkins.mycroft.team/job/20.02-skill-tester/346/console)