### PR TITLE
Validate answer for "for what time"

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -398,7 +398,7 @@ class AlarmSkill(MycroftSkill):
                                                       self.threshold)
 
         if (when is None or when.time() == today.time()) and not is_midnight:
-            r = self.get_response('query.for.when')
+            r = self.get_response('query.for.when', validator=extract_datetime)
             if not r:
                 self.speak_dialog("alarm.schedule.cancelled")
                 return


### PR DESCRIPTION
Use extract_datetime as validator for the sentence to ensure that a time
can be extracted.

Currently if you "set an alarm" and when Mycroft asks "for what time", if you answer strawberries are great the query will fail with an error. This will only accept a time or cancel as valid answer to the question.