### PR TITLE
Add pyalsaaudio to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pyalsaaudio


### PR DESCRIPTION
This dependency is used by the skill but not specified as a dependency.

When https://github.com/MycroftAI/mycroft-core/pull/2575 is merged, it is not guaranteed anymore that pyalsaaudio is installed, so let's make sure it is here at least.