### PR TITLE
Add GUI to Alarm Skill

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1021,7 +1021,7 @@ class AlarmSkill(MycroftSkill):
     def _show_alarm_ui(self, alarm_dt, alarm_name, alarm_exp=False):
         self.gui["alarmTime"] = nice_time(alarm_dt, speech=False,
                                           use_ampm=True)
-        self.gui["alarmName"] = alarm_name
+        self.gui["alarmName"] = alarm_name.title()
         self.gui["alarmExpired"] = alarm_exp
         self.gui.show_page("alarm.qml")
 

--- a/__init__.py
+++ b/__init__.py
@@ -375,8 +375,8 @@ class AlarmSkill(MycroftSkill):
                     data={"time": alarm_nice_time, "rel": reltime},
                 )
 
-        self._show_alarm_anim(alarm_time)
         self._show_alarm_ui(alarm_time, name)
+        self._show_alarm_anim(alarm_time)
         self.enclosure.activate_mouth_events()
 
     def _get_alarm_name(self, utt):

--- a/__init__.py
+++ b/__init__.py
@@ -376,6 +376,7 @@ class AlarmSkill(MycroftSkill):
                 )
 
         self._show_alarm_anim(alarm_time)
+        self._show_alarm_ui(alarm_time, name)
         self.enclosure.activate_mouth_events()
 
     def _get_alarm_name(self, utt):
@@ -707,6 +708,7 @@ class AlarmSkill(MycroftSkill):
                 self.speak_dialog(
                     "alarm.cancelled.desc" + recurring, data={"desc": desc}
                 )
+                self.gui.remove_page("alarm.qml")
                 return
             else:
                 self.speak_dialog("alarm.delete.cancelled")
@@ -723,6 +725,7 @@ class AlarmSkill(MycroftSkill):
                 ]
                 self._schedule()
                 self.speak_dialog("alarm.cancelled.multi", data={"count": total})
+                self.gui.remove_page("alarm.qml")
             return
         elif not total:
             # Failed to delete
@@ -900,6 +903,7 @@ class AlarmSkill(MycroftSkill):
             self.settings["alarm"] = curate_alarms(
                 self.settings["alarm"], 0
             )  # end any expired alarm
+            self.gui.remove_page("alarm.qml")
             self._schedule()
             return True
         else:
@@ -937,6 +941,10 @@ class AlarmSkill(MycroftSkill):
             name="Flash",
             data={"alarm_time": alarm["timestamp"]},
         )
+        alarm_timestamp = alarm.get("timestamp", "")
+        alarm_dt = get_alarm_local(timestamp=alarm_timestamp)
+        alarm_name = alarm.get("name", "")
+        self._show_alarm_ui(alarm_dt, alarm_name, alarm_exp=True)
 
     def __end_flash(self):
         self.cancel_scheduled_event("Flash")
@@ -1009,6 +1017,13 @@ class AlarmSkill(MycroftSkill):
             png = join(abspath(dirname(__file__)), "anim", png)
             self.enclosure.mouth_display_png(png, x=x, y=2, refresh=False)
             x += w
+
+    def _show_alarm_ui(self, alarm_dt, alarm_name, alarm_exp=False):
+        self.gui["alarmTime"] = nice_time(alarm_dt, speech=False,
+                                          use_ampm=True)
+        self.gui["alarmName"] = alarm_name
+        self.gui["alarmExpired"] = alarm_exp
+        self.gui.show_page("alarm.qml")
 
 
 def create_skill():

--- a/__init__.py
+++ b/__init__.py
@@ -708,7 +708,7 @@ class AlarmSkill(MycroftSkill):
                 self.speak_dialog(
                     "alarm.cancelled.desc" + recurring, data={"desc": desc}
                 )
-                self.gui.remove_page("alarm.qml")
+                self.gui.release()
                 return
             else:
                 self.speak_dialog("alarm.delete.cancelled")
@@ -725,7 +725,7 @@ class AlarmSkill(MycroftSkill):
                 ]
                 self._schedule()
                 self.speak_dialog("alarm.cancelled.multi", data={"count": total})
-                self.gui.remove_page("alarm.qml")
+                self.gui.release()
             return
         elif not total:
             # Failed to delete
@@ -903,7 +903,7 @@ class AlarmSkill(MycroftSkill):
             self.settings["alarm"] = curate_alarms(
                 self.settings["alarm"], 0
             )  # end any expired alarm
-            self.gui.remove_page("alarm.qml")
+            self.gui.release()
             self._schedule()
             return True
         else:

--- a/__init__.py
+++ b/__init__.py
@@ -1023,7 +1023,8 @@ class AlarmSkill(MycroftSkill):
                                           use_ampm=True)
         self.gui["alarmName"] = alarm_name.title()
         self.gui["alarmExpired"] = alarm_exp
-        self.gui.show_page("alarm.qml")
+        override_idle = True if alarm_exp else False
+        self.gui.show_page("alarm.qml", override_idle=override_idle)
 
 
 def create_skill():

--- a/ui/alarm.qml
+++ b/ui/alarm.qml
@@ -5,20 +5,16 @@ import Mycroft 1.0 as Mycroft
 import org.kde.kirigami 2.11 as Kirigami
 import QtGraphicalEffects 1.0
 
-Mycroft.Delegate {
+Mycroft.CardDelegate {
     id: root
-    skillBackgroundColorOverlay: "black"
     property bool alarmExpired: sessionData.alarmExpired
     property color alarmColor: alarmExpired ? "#FFFFFF" : "#22A7F0"
-    leftPadding: 0
-    rightPadding: 0
-    topPadding: 0
-    bottomPadding: 0
+    cardBackgoundOverlayColor: "black"
     
     Rectangle {
         id: leftRect
         anchors.top: parent.top
-        anchors.topMargin: Math.round(centerRect.height * 0.085)
+        anchors.topMargin: Mycroft.Units.gridUnit - 2
         anchors.right: centerRect.left
         anchors.rightMargin: Math.round(-centerRect.width * 0.340)
         color: alarmColor
@@ -34,7 +30,7 @@ Mycroft.Delegate {
     Rectangle {
         id: rightRect
         anchors.top: parent.top
-        anchors.topMargin: Math.round(centerRect.height * 0.085)
+        anchors.topMargin: Mycroft.Units.gridUnit - 2
         anchors.left: centerRect.right
         anchors.leftMargin: Math.round(-centerRect.width * 0.340)
         color: alarmColor
@@ -55,10 +51,10 @@ Mycroft.Delegate {
         anchors.leftMargin: -centerRect.width * 0.20
         color: alarmColor
         radius: 30
-        rotation: -50
+        rotation: -48
         z: 2
         width: centerRect.width * 0.16
-        height: centerRect.height * 0.25
+        height: centerRect.height * 0.28
     }
 
     Rectangle {
@@ -69,20 +65,20 @@ Mycroft.Delegate {
         anchors.rightMargin: -centerRect.width * 0.20
         color: alarmColor
         radius: 30
-        rotation: 50
+        rotation: 48
         z: 2
         width: centerRect.width * 0.16
-        height: centerRect.height * 0.25
+        height: centerRect.height * 0.28
     }
 
     Rectangle {
         id: centerRect
         anchors.top: parent.top
-        anchors.topMargin: Kirigami.Units.largeSpacing + Kirigami.Units.smallSpacing
+        anchors.topMargin: Mycroft.Units.gridUnit + 5
         anchors.horizontalCenter: parent.horizontalCenter
         color: "black"
         radius: width
-        width: Math.min(Math.round(parent.width / 2.1050), 800)
+        width: Math.min(Math.round(parent.width / 2.480), 800)
         height: width
 
         Rectangle {
@@ -99,16 +95,16 @@ Mycroft.Delegate {
 
                 Label {
                     id: timeI
-                    anchors.verticalCenter: parent.verticalCenter
-                    anchors.horizontalCenter: parent.horizontalCenter
+                    anchors.centerIn: parent
                     font.weight: Font.ExtraBold
-                    font.pixelSize: parent.height * 0.375
-                    color: "black"
-                    font.family: "Noto Sans SemiBold"
+                    font.pixelSize: timeI.text.length > 4 ? parent.width * 0.35 : parent.width * 0.40
+                    color: sessionData.alarmExpired ? "black" : "white"
+                    font.family: "Noto Sans Display"
+                    font.styleName: "bold"
                     font.letterSpacing: 2
                     text: sessionData.alarmTime.split(" ")[0]
                     z: 100
-                    
+
                     SequentialAnimation on opacity {
                         id: expireAnimation
                         running: alarmExpired
@@ -130,16 +126,17 @@ Mycroft.Delegate {
                 Label {
                     id: ampm
                     anchors.top: timeI.baseline
-                    anchors.topMargin: 24
+                    anchors.topMargin: 15
                     anchors.horizontalCenter: parent.horizontalCenter
                     font.weight: Font.Bold
                     font.family: "Noto Sans Display"
-                    font.pixelSize: parent.height * 0.14
+                    font.styleName: "bold"
+                    font.pixelSize: parent.height * 0.175
                     font.letterSpacing: 2
-                    color: "black"
+                    color: sessionData.alarmExpired ? "black" : "white"
                     text: sessionData.alarmTime.split(" ")[1]
                     z: 100
-                    
+
                     SequentialAnimation on opacity {
                         id: expireAnimation2
                         running: alarmExpired
@@ -162,9 +159,10 @@ Mycroft.Delegate {
     }
 
     Rectangle {
+        id: alarmLabelBox
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.bottom: parent.bottom
-        anchors.bottomMargin: Kirigami.Units.largeSpacing + Kirigami.Units.smallSpacing
+        anchors.bottomMargin: Mycroft.Units.gridUnit * 2 - 5
         width: centerRect.width
         color: "transparent"
         height: alarmLabel.contentHeight
@@ -177,11 +175,11 @@ Mycroft.Delegate {
             horizontalAlignment: Text.AlignHCenter
             verticalAlignment: Text.AlignVCenter
             font.weight: Font.Bold
-            font.family: "Noto Sans Display SemiBold"
+            font.family: "Noto Sans Display"
+            font.styleName: "SemiBold"
             font.pixelSize: parent.width * 0.12
             font.letterSpacing: 2
             text: sessionData.alarmName
         }
     }
 }
- 

--- a/ui/alarm.qml
+++ b/ui/alarm.qml
@@ -1,0 +1,187 @@
+import QtQuick 2.12
+import QtQuick.Controls 2.5
+import QtQuick.Layouts 1.3
+import Mycroft 1.0 as Mycroft
+import org.kde.kirigami 2.11 as Kirigami
+import QtGraphicalEffects 1.0
+
+Mycroft.Delegate {
+    id: root
+    skillBackgroundColorOverlay: "black"
+    property bool alarmExpired: sessionData.alarmExpired
+    property color alarmColor: alarmExpired ? "#FFFFFF" : "#22A7F0"
+    leftPadding: 0
+    rightPadding: 0
+    topPadding: 0
+    bottomPadding: 0
+    
+    Rectangle {
+        id: leftRect
+        anchors.top: parent.top
+        anchors.topMargin: Math.round(centerRect.height * 0.085)
+        anchors.right: centerRect.left
+        anchors.rightMargin: Math.round(-centerRect.width * 0.340)
+        color: alarmColor
+        radius: width
+        width: parent.width / 6
+        height: width
+        layer.enabled: true
+        layer.effect: OpacityMask {
+            maskSource: centerRect
+        }
+    }
+
+    Rectangle {
+        id: rightRect
+        anchors.top: parent.top
+        anchors.topMargin: Math.round(centerRect.height * 0.085)
+        anchors.left: centerRect.right
+        anchors.leftMargin: Math.round(-centerRect.width * 0.340)
+        color: alarmColor
+        radius: width
+        width: parent.width / 6
+        height: width
+        layer.enabled: true
+        layer.effect: OpacityMask {
+            maskSource: centerRect
+        }
+    }
+
+    Rectangle {
+        id: rightBottomRect
+        anchors.top: centerRect.bottom
+        anchors.topMargin: -centerRect.height * 0.30
+        anchors.left: centerRect.right
+        anchors.leftMargin: -centerRect.width * 0.20
+        color: alarmColor
+        radius: 30
+        rotation: -50
+        z: 2
+        width: centerRect.width * 0.16
+        height: centerRect.height * 0.25
+    }
+
+    Rectangle {
+        id: leftBottomRect
+        anchors.top: centerRect.bottom
+        anchors.topMargin: -centerRect.height * 0.30
+        anchors.right: centerRect.left
+        anchors.rightMargin: -centerRect.width * 0.20
+        color: alarmColor
+        radius: 30
+        rotation: 50
+        z: 2
+        width: centerRect.width * 0.16
+        height: centerRect.height * 0.25
+    }
+
+    Rectangle {
+        id: centerRect
+        anchors.top: parent.top
+        anchors.topMargin: Kirigami.Units.largeSpacing + Kirigami.Units.smallSpacing
+        anchors.horizontalCenter: parent.horizontalCenter
+        color: "black"
+        radius: width
+        width: Math.min(Math.round(parent.width / 2.1050), 800)
+        height: width
+
+        Rectangle {
+            id: centerRectInner
+            anchors.centerIn: parent
+            color: alarmColor
+            radius: width
+            width: Math.round(parent.width / 1.1180)
+            height: width
+            z: 5
+
+            Item {
+                anchors.fill: parent
+
+                Label {
+                    id: timeI
+                    anchors.verticalCenter: parent.verticalCenter
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    font.weight: Font.ExtraBold
+                    font.pixelSize: parent.height * 0.375
+                    color: "black"
+                    font.family: "Noto Sans SemiBold"
+                    font.letterSpacing: 2
+                    text: sessionData.alarmTime.split(" ")[0]
+                    z: 100
+                    
+                    SequentialAnimation on opacity {
+                        id: expireAnimation
+                        running: alarmExpired
+                        loops: Animation.Infinite
+                        PropertyAnimation {
+                            from: 1;
+                            to: 0;
+                            duration: 500
+                        }
+
+                        PropertyAnimation {
+                            from: 0;
+                            to: 1;
+                            duration: 500
+                        }
+                    }
+                }
+
+                Label {
+                    id: ampm
+                    anchors.top: timeI.baseline
+                    anchors.topMargin: 24
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    font.weight: Font.Bold
+                    font.family: "Noto Sans Display"
+                    font.pixelSize: parent.height * 0.14
+                    font.letterSpacing: 2
+                    color: "black"
+                    text: sessionData.alarmTime.split(" ")[1]
+                    z: 100
+                    
+                    SequentialAnimation on opacity {
+                        id: expireAnimation2
+                        running: alarmExpired
+                        loops: Animation.Infinite
+                        PropertyAnimation {
+                            from: 1;
+                            to: 0;
+                            duration: 500
+                        }
+
+                        PropertyAnimation {
+                            from: 0;
+                            to: 1;
+                            duration: 500
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Rectangle {
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.bottom: parent.bottom
+        anchors.bottomMargin: Kirigami.Units.largeSpacing + Kirigami.Units.smallSpacing
+        width: centerRect.width
+        color: "transparent"
+        height: alarmLabel.contentHeight
+
+        Label {
+            id: alarmLabel
+            color: "white"
+            width: parent.width
+            font.bold: true
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+            font.weight: Font.Bold
+            font.family: "Noto Sans Display SemiBold"
+            font.pixelSize: parent.width * 0.12
+            font.letterSpacing: 2
+            text: sessionData.alarmName
+        }
+    }
+}
+ 


### PR DESCRIPTION
#### Description
Extension of PR #111 - adding new GUI to Alarm Skill courtesy of @AIIX

- Title case for Alarm names
- Switch display methods so that the less blocking QML display is first, then the blocking Mark 1 animation gets called. Hence the Skill appears more responsive on a Mark II.
- Override_idle for expired alarms to show flashing screen until it is intentionally cleared.
- Release GUI when expired alarm is stopped as no other Alarm screen should return at that time.

Note: requires this Fix in the Mark II Skill to work properly:
https://github.com/MycroftAI/skill-mark-2/pull/59

#### Type of PR
- [x] Feature implementation

#### Testing
- Set an alarm
- Wait for the new alarm screen to disappear
- Wait for alarm to expire
- wait for more than 30 seconds to show override idle is working
- stop the expired alarm and should return to Homescreen.

#### Documentation
NA

#### CLA
- [x] Yes