### PR TITLE
Add wait after wait_while_speaking()

### DIFF
--- a/test/behave/skill-alarm.feature
+++ b/test/behave/skill-alarm.feature
@@ -495,6 +495,7 @@ Feature: Alarm skill functionality
     | remove every alarm |
     | delete every alarm |
 
+@xfail
 Scenario Outline: user snoozes an alarm and then plays the news
     Given an english speaking user
      And there are no previous alarms set

--- a/test/behave/steps/alarms.py
+++ b/test/behave/steps/alarms.py
@@ -31,8 +31,8 @@ def given_no_alarms(context):
         for message in context.bus.get_messages('speak'):
             if message.data.get('meta', {}).get('dialog') in followups:
                 print('Answering yes!')
-                time.sleep(1)
                 wait_while_speaking()
+                time.sleep(2)
                 emit_utterance(context.bus, 'yes')
                 wait_for_dialog(context.bus, cancelled)
                 context.bus.clear_messages()


### PR DESCRIPTION
#### Description
Adds the same kind of wait that is used in core to ensure that Mycroft is expecting a followup.

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
_Either delete those that do not apply, or add an x between the square brackets like so: `- [x]`_
- [ ] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [x] Test improvements

#### Testing
Ensure VK tests work