### PR TITLE
Skill API methods providing VK test improvements

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1055,6 +1055,12 @@ class AlarmSkill(MycroftSkill):
         """
         return self.settings["alarm"]
 
+    @skill_api_method
+    def is_alarm_expired(self):
+        """Check if an alarm is currently expired and beeping."""
+        return has_expired_alarm(self.settings["alarm"])
+
+
 def create_skill():
     """Create the Alarm Skill for Mycroft."""
     return AlarmSkill()

--- a/__init__.py
+++ b/__init__.py
@@ -1039,6 +1039,21 @@ class AlarmSkill(MycroftSkill):
         else:
             return False
 
+    @skill_api_method
+    def get_active_alarms(self):
+        """Get list of active alarms.
+
+        This includes any alarms that are in an expired state.
+
+        Returns:
+            List of alarms as Objects: {
+                "timestamp" (float): POSIX timestamp of next alarm expiry
+                "repeat_rule" (str): iCal repeat rule
+                "name" (str): Alarm name
+                "snooze" (float): [optional] POSIX timestamp if alarm was snoozed
+            }
+        """
+        return self.settings["alarm"]
 
 def create_skill():
     """Create the Alarm Skill for Mycroft."""

--- a/__init__.py
+++ b/__init__.py
@@ -1035,6 +1035,7 @@ class AlarmSkill(MycroftSkill):
         """Delete all stored alarms."""
         if len(self.settings["alarm"]) > 0:
             self.settings["alarm"] = []
+            self._schedule()
             return True
         else:
             return False

--- a/__init__.py
+++ b/__init__.py
@@ -23,6 +23,7 @@ from adapt.intent import IntentBuilder
 from mycroft import MycroftSkill, intent_handler
 from mycroft.configuration.config import LocalConf, USER_CONFIG
 from mycroft.messagebus.message import Message
+from mycroft.skills import skill_api_method
 from mycroft.util import play_mp3
 from mycroft.util.format import nice_date_time, nice_time, nice_date, join_list
 from mycroft.util.parse import extract_datetime, extract_number
@@ -1025,6 +1026,18 @@ class AlarmSkill(MycroftSkill):
         self.gui["alarmExpired"] = alarm_exp
         override_idle = True if alarm_exp else False
         self.gui.show_page("alarm.qml", override_idle=override_idle)
+
+    ##########################################################################
+    # Public Skill API Methods
+
+    @skill_api_method
+    def delete_all_alarms(self):
+        """Delete all stored alarms."""
+        if len(self.settings["alarm"]) > 0:
+            self.settings["alarm"] = []
+            return True
+        else:
+            return False
 
 
 def create_skill():

--- a/test/behave/steps/alarms.py
+++ b/test/behave/steps/alarms.py
@@ -3,6 +3,7 @@ import time
 from behave import given, then
 
 from mycroft.audio import wait_while_speaking
+from mycroft.skills.api import SkillApi
 
 from test.integrationtests.voight_kampff import emit_utterance, wait_for_dialog
 
@@ -16,32 +17,9 @@ def given_set_alarm(context, alarm_time):
 
 @given('there are no previous alarms set')
 def given_no_alarms(context):
-    followups = ['ask.cancel.alarm.plural',
-                 'ask.cancel.desc.alarm',
-                 'ask.cancel.desc.alarm.recurring']
-    no_alarms = ['alarms.list.empty']
-    cancelled = ['alarm.cancelled.desc',
-                 'alarm.cancelled.desc.recurring',
-                 'alarm.cancelled.multi',
-                 'alarm.cancelled.recurring']
-
-    print('ASKING QUESTION')
-    emit_utterance(context.bus, 'cancel all alarms')
-    for i in range(10):
-        for message in context.bus.get_messages('speak'):
-            if message.data.get('meta', {}).get('dialog') in followups:
-                print('Answering yes!')
-                wait_while_speaking()
-                time.sleep(2)
-                emit_utterance(context.bus, 'yes')
-                wait_for_dialog(context.bus, cancelled)
-                context.bus.clear_messages()
-                return
-            elif message.data.get('meta', {}).get('dialog') in no_alarms:
-                context.bus.clear_messages()
-                return
-        time.sleep(1)
-    context.bus.clear_messages()
+    SkillApi.connect_bus(context.bus)
+    alarm_skill = SkillApi.get('mycroft-alarm.mycroftai')
+    alarm_skill.delete_all_alarms()
 
 
 @given('an alarm is expired and beeping')

--- a/test/behave/steps/alarms.py
+++ b/test/behave/steps/alarms.py
@@ -20,6 +20,8 @@ def given_no_alarms(context):
     SkillApi.connect_bus(context.bus)
     alarm_skill = SkillApi.get('mycroft-alarm.mycroftai')
     alarm_skill.delete_all_alarms()
+    active_alarms = alarm_skill.get_active_alarms()
+    assert(len(active_alarms) == 0)
 
 
 @given('an alarm is expired and beeping')

--- a/test/behave/steps/alarms.py
+++ b/test/behave/steps/alarms.py
@@ -24,8 +24,8 @@ def given_no_alarms(context):
 
 @given('an alarm is expired and beeping')
 def given_expired_alarm(context):
-    emit_utterance(context.bus, 'set an alarm in 30 seconds')
-    time.sleep(30)
+    emit_utterance(context.bus, 'set an alarm in 10 seconds')
+    time.sleep(12)
 
 
 @then('"mycroft-alarm" should stop beeping')

--- a/test/behave/steps/alarms.py
+++ b/test/behave/steps/alarms.py
@@ -32,5 +32,7 @@ def given_expired_alarm(context):
 
 @then('"mycroft-alarm" should stop beeping')
 def then_stop_beeping(context):
-    # TODO Implement
-    pass
+    time.sleep(2)
+    SkillApi.connect_bus(context.bus)
+    alarm_skill = SkillApi.get('mycroft-alarm.mycroftai')
+    assert(not alarm_skill.is_alarm_expired())


### PR DESCRIPTION
#### Description
Adds API methods for:
- Deleting all alarms
- Getting list of alarms
- Determining if there is currently an alarm going off.

These are then used to improve the Voight Kampff custom Steps, including implementing an actual check that the alarm has been stopped.

This should make the tests more consistent and run faster as it no longer relies on back and forth "voice" commands over the bus.

#### Type of PR
- [x] Feature implementation
- [x] Test improvements

#### Testing
```
mycroft-start vktest -t mycroft-alarm --tags=~@xfail
```
