### PR TITLE
fix property name

### DIFF
--- a/ui/alarm.qml
+++ b/ui/alarm.qml
@@ -9,7 +9,7 @@ Mycroft.CardDelegate {
     id: root
     property bool alarmExpired: sessionData.alarmExpired
     property color alarmColor: alarmExpired ? "#FFFFFF" : "#22A7F0"
-    cardBackgoundOverlayColor: "black"
+    cardBackgroundOverlayColor: "black"
     
     Rectangle {
         id: leftRect


### PR DESCRIPTION
#### Description
Does not allow the GUI to show up on more recent mycroft-gui because the property name in ui is wrong.

- Fix property name stopping as per fix in mycroft-gui

#### Type of PR
- [x] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements